### PR TITLE
The only change needed for it to work in IE8 (at least to some extent)

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ function createXHR(options, callback) {
     var headers = xhr.headers = options.headers || {}
     var sync = !!options.sync
     var isJson = false
+    var key
 
     if ("json" in options) {
         isJson = true
@@ -63,9 +64,11 @@ function createXHR(options, callback) {
     }
 
     if (xhr.setRequestHeader) {
-        Object.keys(headers).forEach(function (key) {
-            xhr.setRequestHeader(key, headers[key])
-        })
+        for(key in headers){
+            if(headers.hasOwnProperty(key)){
+                xhr.setRequestHeader(key, headers[key])
+            }
+        }
     }
 
     if ("responseType" in options) {


### PR DESCRIPTION
I tested my browserify code in IE8 and discovered two things:
1. devtools in IE8 were horrible
2. you only need to remove one forEach to get simple XHR working in IE8 (not tested with cors)

So this is it. The change is minor, doesn't break anything and adds more support, so I guess it's worth it.
