### PR TITLE
Prevent error in error handling when responseType is changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,8 +96,13 @@ function createXHR(options, callback) {
         }
 
         if (status === 0 || (status >= 400 && status < 600)) {
-            var message = xhr.responseText ||
-                messages[String(xhr.status).charAt(0)]
+            var message;
+            try{
+            message = xhr.responseText;
+            }catch(e){
+                // accessing xhr.responseText can throw errors when xhr.responseType is changed
+            }
+            message = message || messages[String(xhr.status).charAt(0)];
             error = new Error(message)
 
             error.statusCode = xhr.status


### PR DESCRIPTION
xhr allows setting `responseType` option, but when a call ends up in HTTP error, the error handler accesses `responseText` property. Some `responseType`s cause the browser to throw when `tesponseText` is accessed. This PR fixes the issue by ignoring the error and writing a default message instead. The actual response text could be accessed via xhr.body probably, could be done in the 'catch' section.

_I saw you like handling errors so I handled an error in your error handler so it can handle errors while it's handling errors_
