### PR TITLE
Added Accept header to show we want JSON in return

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function createXHR(options, callback) {
 
     if ("json" in options) {
         isJson = true
+        headers["Accept"] = "application/json"
         if (method !== "GET" && method !== "HEAD") {
             headers["Content-Type"] = "application/json"
             body = JSON.stringify(options.json)


### PR DESCRIPTION
A number of libraries (eg, the Express error handler) use the Accept header to determine whether they can send JSON back - and I think it's reasonable to say we're expecting JSON in return given that it's parsed on the response.
