### PR TITLE
A test for throwing on headers added to XDR in IE8/9

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -65,5 +65,14 @@ test("XDR usage (run on IE8 or 9)", function(assert) {
         "Uses XDR with deprecated option cors"
     )
     
+    if(!!window.XDomainRequest){
+        assert.throws(function(){
+            xhr({
+                useXDR: true,
+                uri: window.location.href,
+                headers:{"foo":"bar"}
+            }, function () {})
+        },true,"Throws when trying to send headers with XDR")
+    }
     assert.end()
 })


### PR DESCRIPTION
A test I used to make sure an error is thrown in IE after we had issues with the throw statement. 
