### PR TITLE
add better 0 error description

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var once = require("once")
 var parseHeaders = require('parse-headers')
 
 var messages = {
-    "0": "Internal XMLHttpRequest Error",
+    "0": "Internal XMLHttpRequest Error - set XHR timeout has been reached.",
     "4": "4xx Client Error",
     "5": "5xx Server Error"
 }


### PR DESCRIPTION
The timeout error message was very cryptic when I used it. It took a very long time to understand that xhr was setting the timeout automatically and it wasn't an issue with Chrome/my own code.
