### PR TITLE
optional callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,7 @@ function createXHR(options, callback) {
     }
 
     options = options || {}
+    callback = callback || noop
     callback = once(callback)
 
     var xhr = options.xhr || null


### PR DESCRIPTION
there are occasions when i dont care about server responses to `xhr()`

when the server response doesn't matter but you still want to fire-and-forget some type of request, then the callback ought to be optional:

``` js
xhr({
  body:JSON.stringify(whatever),
  uri:'/foo',
  headers:{'content-type':'application/json'}
})
```

this makes the callback more optional by preventing an error when
`once()` calls `apply()` on the unregistered (meaning non-existent)
callback, i.e. not passed to the exported xhr() constructor.
