### PR TITLE
Allow optional options.onprogress func

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ Determines the data type of the `response`. Sets [`xhr.responseType`][11]. For e
 
 Pass an `XMLHttpRequest` object (or something that acts like one) to use instead of constructing a new one using the `XMLHttpRequest` or `XDomainRequest` constructors. Useful for testing.
 
+### `options.onprogress`
+
+Specify your own onprogress - callback function
+
+### `options.upload.onprogress`
+
+Specify your own upload.onprogress - callback function
+```js
+var xhr = require("xhr")
+
+xhr({
+    body: someJSONString,
+    uri: "/foo",
+    method: "POST",
+    upload: {
+        onprogress: function(e) {
+            console.log(e);
+        }
+    }
+}, function (err, resp, body) {
+    // check resp.statusCode
+})
+```
+
 ## MIT Licenced
 
   [1]: http://xhr.spec.whatwg.org/#the-send()-method

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function createXHR(options, callback) {
     xhr.onload = loadFunc
     xhr.onerror = errorFunc
     // IE9 must have onprogress be set to a unique function.
-    xhr.onprogress = function () {
+    xhr.onprogress = options.onprogress || function () {
         // IE must die
     }
     xhr.ontimeout = errorFunc

--- a/index.js
+++ b/index.js
@@ -125,6 +125,11 @@ function createXHR(options, callback) {
     xhr.onprogress = options.onprogress || function () {
         // IE must die
     }
+    if(xhr.upload && options.upload)
+        xhr.upload.onprogress = options.upload.onprogress || function () {
+            // IE must die
+        }
+
     xhr.ontimeout = errorFunc
     xhr.open(method, uri, !sync)
     //has to be after open

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neoscores/xhr",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "small xhr abstraction",
   "keywords": [
     "xhr",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xhr",
+  "name": "@neoscores/xhr",
   "version": "2.0.1",
   "description": "small xhr abstraction",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -140,3 +140,30 @@ test("constructs and calls callback without throwing", function (assert) {
     }, "callback is not optional")
     assert.end()
 })
+
+test("handles onprogressFunc ", function (assert) {
+    xhr({
+        onprogress: function(e) {
+            assert.ok(e && e.type === 'progress', "callback should get a ProgressEvent");
+        },
+        uri: window.location.href,
+    }, function (err, resp, body) {
+        assert.ok(true, "got here")
+        assert.end()
+    })
+})
+
+test("handles onUploadProgressFunc ", function (assert) {
+    xhr({
+        method: 'POST',
+        upload: {
+            onprogress: function(e) {
+                assert.ok(e && e.type === 'progress', "callback should get a ProgressEvent");
+            }
+        },
+        uri: window.location.href,
+    }, function (err, resp, body) {
+        assert.ok(true, "got here")
+        assert.end()
+    })
+})


### PR DESCRIPTION
Allow an optional onprogress function if needed (for a native webapp which only needs support on latests iOS, Android and Windows devices)
