### PR TITLE
Fix failure response when we make request to non-allowed cross-domain url

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,15 +88,6 @@ function _createXHR(options) {
         return body
     }
 
-    var failureResponse = {
-                body: undefined,
-                headers: {},
-                statusCode: 0,
-                method: method,
-                url: uri,
-                rawRequest: xhr
-            }
-
     function errorFunc(evt) {
         clearTimeout(timeoutTimer)
         if(!(evt instanceof Error)){
@@ -157,6 +148,14 @@ function _createXHR(options) {
     var sync = !!options.sync
     var isJson = false
     var timeoutTimer
+    var failureResponse = {
+        body: undefined,
+        headers: {},
+        statusCode: 0,
+        method: method,
+        url: uri,
+        rawRequest: xhr
+    }
 
     if ("json" in options && options.json !== false) {
         isJson = true

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,17 @@ test("[func] Returns http error responses like npm's request (cross-domain)", fu
     }
 })
 
+test("[func] Request to domain with not allowed cross-domain", function(assert) {
+    xhr({
+        uri: "http://www.mocky.io/v2/57bb70c21000002f175850bd",
+    }, function(err, resp, body) {
+        assert.ok(err instanceof Error, "should return error")
+        assert.equal(resp.statusCode, 0)
+        assert.equal(typeof resp.rawRequest, "object")
+        assert.end()
+    })
+})
+
 test("[func] Returns a falsy body for 204 responses", function(assert) {
     xhr({
         uri: "/mock/no-content"


### PR DESCRIPTION
When we initialize `failureResponse` [here](https://github.com/Raynos/xhr/blob/master/index.js#L91) `xhr` variable not initialized yet.

So, if we have a fired onError (for example request to non-allowed cross-domain requests url) we have `undefined` `xhr` in `resp.rawRequest`.

Fixed it and wrote the test for that case.
