### PR TITLE
Add Option: ignoreHeadersWhenXDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,12 @@ A function being called right before the `send` method of the `XMLHttpRequest` o
 
 Pass an `XMLHttpRequest` object (or something that acts like one) to use instead of constructing a new one using the `XMLHttpRequest` or `XDomainRequest` constructors. Useful for testing.
 
+### `options.ignoreHeadersWhenXDR`
+
+Specify whether it is (or is not) an error to pass HTTP headers in a cross origin (CORS) request for IE<10.
+    When _not_ present, passing HTTP headers to `xhr` when `useXDR` is truthy on IE<10 will result in an
+    error being thrown.  When `ignoreHeadersWhenXDR` is present an error will _not_ be thrown.
+
 ## FAQ
 
 - Why is my server's JSON response not parsed? I returned the right content-type.

--- a/index.js
+++ b/index.js
@@ -200,7 +200,9 @@ function _createXHR(options) {
             }
         }
     } else if (options.headers && !isEmpty(options.headers)) {
-        throw new Error("Headers cannot be set on an XDomainRequest object")
+        if (('ignoreHeadersWhenXDR' in options) == false || !!!options.ignoreHeadersWhenXDR) {
+            throw new Error("Headers cannot be set on an XDomainRequest object")
+        }
     }
 
     if ("responseType" in options) {


### PR DESCRIPTION
Add Option: ignoreHeadersWhenXDR

Allow caller to decide if it is an error to pass HTTP headers to CORS requests in IE<10.
    
This is useful in scenarios when the library is being used to make XDR calls and handle the difference between legacy and modern browsers (i.e. transparently choose to use either XMLHttpRequest or XDomainRequest as appropriate on behalf of the library user).