### PR TITLE
Align json option with request, improved to include input from #134 comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Pass an `XMLHttpRequest` object (or something that acts like one) to use instead
 - How do I send an object or array as POST body?
   - `options.body` should be a string. You need to serialize your object before passing to `xhr` for sending.
   - To serialize to JSON you can use
-   `options.json` instead of `options.body` for convenience - then `xhr` will do the serialization and set content-type accordingly.
+   `options.json:true` with `options.body` for convenience - then `xhr` will do the serialization and set content-type accordingly.
 - Where's stream API? `.pipe()` etc.
   - Not implemented. You can't reasonably have that in the browser.
 - Why can't I send `"true"` as body by passing it as `options.json` anymore?

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ type XhrOptions = String | {
     method: String?,
     timeout: Number?,
     headers: Object?,
-    body: String||Object?,
-    json: Boolean?,
+    body: String? | Object?,
+    json: Boolean? | Object?,
     username: String?,
     password: String?,
     withCredentials: Boolean?,
@@ -148,7 +148,7 @@ Pass in body to be send across the [`XMLHttpRequest`][3].
     Generally should be a string. But anything that's valid as
     a parameter to [`XMLHttpRequest.send`][1] should work  (Buffer for file, etc.).
 
-If `options.json` is `true`, then this must be a JSON-serializable object.
+If `options.json` is `true`, then this must be a JSON-serializable object. `options.body` is passed to `JSON.stringify` and sent.
 
 ### `options.uri` or `options.url`
 
@@ -165,10 +165,11 @@ Number of miliseconds to wait for response. Defaults to 0 (no timeout). Ignored 
 
 ### `options.json`
 
-If set to `true` then we serialize the value of `options.body` and send that as the request body.
-    We also set the Content-Type to `"application/json"`.
+Set to `true` to send request as `application/json` (see `options.body`) and parse response from JSON.
 
-Additionally the response body is parsed as JSON
+For backwards compatibility `options.json` can also be a valid JSON-serializable value to be sent to the server. Additionally the response body is still parsed as JSON
+
+For sending booleans as JSON body see FAQ
 
 ### `options.withCredentials`
 
@@ -196,14 +197,13 @@ Pass an `XMLHttpRequest` object (or something that acts like one) to use instead
   - See `options.json` - you can set it to `true` on a GET request to tell `xhr` to parse the response body.
   - Without `options.json` body is returned as-is (a string or when `responseType` is set and the browser supports it - a result of parsing JSON or XML)
 - How do I send an object or array as POST body?
-  - `options.body` should be a string or any other value that's valid as
-  a parameter to [`XMLHttpRequest.send`][1]. Any other value needs to
-  be serialized before passed to `xhr` for sending.
-  - To serialize to JSON you can set
-   `options.json` to `true` for convenience - then `xhr` will do the serialization and set content-type accordingly.
+  - `options.body` should be a string. You need to serialize your object before passing to `xhr` for sending.
+  - To serialize to JSON you can use
+   `options.json` instead of `options.body` for convenience - then `xhr` will do the serialization and set content-type accordingly.
 - Where's stream API? `.pipe()` etc.
   - Not implemented. You can't reasonably have that in the browser.
-
+- Why can't I send `"true"` as body by passing it as `options.json` anymore?
+  - Accepting `true` as a value was a bug. Despite what `JSON.stringify` does, the string `"true"` is not valid JSON. If you're sending booleans as JSON, please consider wrapping them in an object or array to save yourself from more trouble in the future. To bring back the old behavior, hardcode `options.json` to `true` and set `options.body` to your boolean value. 
 
 ## Mocking Requests
 You can override the constructor used to create new requests for testing. When you're making a new request:

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ type XhrOptions = String | {
     method: String?,
     timeout: Number?,
     headers: Object?,
-    body: String?,
-    json: Object?,
+    body: String||Object?,
+    json: Boolean?,
     username: String?,
     password: String?,
     withCredentials: Boolean?,
@@ -148,6 +148,8 @@ Pass in body to be send across the [`XMLHttpRequest`][3].
     Generally should be a string. But anything that's valid as
     a parameter to [`XMLHttpRequest.send`][1] should work  (Buffer for file, etc.).
 
+If `options.json` is `true`, then this must be a JSON-serializable object.
+
 ### `options.uri` or `options.url`
 
 The uri to send a request to. Passed to [`XMLHttpRequest.open`][2]. `options.url` and `options.uri` are aliases for each other.
@@ -163,8 +165,7 @@ Number of miliseconds to wait for response. Defaults to 0 (no timeout). Ignored 
 
 ### `options.json`
 
-A valid JSON serializable value to be send to the server. If this
-    is set then we serialize the value and use that as the body.
+If set to `true` then we serialize the value of `options.body` and send that as the request body.
     We also set the Content-Type to `"application/json"`.
 
 Additionally the response body is parsed as JSON
@@ -195,9 +196,11 @@ Pass an `XMLHttpRequest` object (or something that acts like one) to use instead
   - See `options.json` - you can set it to `true` on a GET request to tell `xhr` to parse the response body.
   - Without `options.json` body is returned as-is (a string or when `responseType` is set and the browser supports it - a result of parsing JSON or XML)
 - How do I send an object or array as POST body?
-  - `options.body` should be a string. You need to serialize your object before passing to `xhr` for sending.
-  - To serialize to JSON you can use
-   `options.json` instead of `options.body` for convenience - then `xhr` will do the serialization and set content-type accordingly.
+  - `options.body` should be a string or any other value that's valid as
+  a parameter to [`XMLHttpRequest.send`][1]. Any other value needs to
+  be serialized before passed to `xhr` for sending.
+  - To serialize to JSON you can set
+   `options.json` to `true` for convenience - then `xhr` will do the serialization and set content-type accordingly.
 - Where's stream API? `.pipe()` etc.
   - Not implemented. You can't reasonably have that in the browser.
 

--- a/index.js
+++ b/index.js
@@ -158,12 +158,12 @@ function _createXHR(options) {
     var isJson = false
     var timeoutTimer
 
-    if (options.json === true) {
+    if ("json" in options) {
         isJson = true
         headers["accept"] || headers["Accept"] || (headers["Accept"] = "application/json") //Don't override existing accept header declared by user
         if (method !== "GET" && method !== "HEAD") {
             headers["content-type"] || headers["Content-Type"] || (headers["Content-Type"] = "application/json") //Don't override existing accept header declared by user
-            body = JSON.stringify(options.body)
+            body = JSON.stringify(options.json === true ? body : options.json)
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -158,12 +158,12 @@ function _createXHR(options) {
     var isJson = false
     var timeoutTimer
 
-    if ("json" in options) {
+    if (options.json === true) {
         isJson = true
         headers["accept"] || headers["Accept"] || (headers["Accept"] = "application/json") //Don't override existing accept header declared by user
         if (method !== "GET" && method !== "HEAD") {
             headers["content-type"] || headers["Content-Type"] || (headers["Content-Type"] = "application/json") //Don't override existing accept header declared by user
-            body = JSON.stringify(options.json)
+            body = JSON.stringify(options.body)
         }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -189,6 +189,16 @@ test("xhr[method] get, put, post, patch with url shorthands", function(assert) {
     })
 })
 
+test("json encoded request body", function(assert) {
+    xhr.post("/mock/echo", {
+        json: true,
+        body: {foo: "bar"}
+    }, function(err, resp, body) {
+        assert.equal(resp.rawRequest.headers["Content-Type"], "application/json")
+        assert.deepEqual(body, {foo: "bar"})
+        assert.end()
+    })
+})
 
 test("xhr[method] get, put, post, patch with url shorthands and options", function(assert) {
     var i = 0

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,6 @@ test("[func] Returns http error responses like npm's request (cross-domain)", fu
     if (!window.XDomainRequest) {
         xhr({
             uri: "http://www.mocky.io/v2/55a02d63265126221a94f025",
-            useXDR: true
         }, function(err, resp, body) {
             assert.ifError(err, "no err")
             assert.equal(resp.statusCode, 404)
@@ -55,18 +54,18 @@ test("[func] Returns a falsy body for 204 responses", function(assert) {
 test("[func] Calls the callback at most once even if error is thrown issue #127", function(assert) {
     //double call happened in chrome
     var count = 0;
-    setTimeout(function(){
+    setTimeout(function() {
         assert.ok(count <= 1, "expected at most one call")
         assert.end()
-    },100)
-    try{
+    }, 100)
+    try {
         xhr({
             uri: "instanterror://foo"
         }, function(err, resp, body) {
             count++;
             throw Error("dummy error")
         })
-    } catch(e){}
+    } catch (e) {}
 })
 
 test("[func] Times out to an error ", function(assert) {
@@ -189,13 +188,31 @@ test("xhr[method] get, put, post, patch with url shorthands", function(assert) {
     })
 })
 
-test("json encoded request body", function(assert) {
+test("[func] sends options.body as json body when options.json === true", function(assert) {
     xhr.post("/mock/echo", {
         json: true,
-        body: {foo: "bar"}
+        body: {
+            foo: "bar"
+        }
     }, function(err, resp, body) {
         assert.equal(resp.rawRequest.headers["Content-Type"], "application/json")
-        assert.deepEqual(body, {foo: "bar"})
+        assert.deepEqual(body, {
+            foo: "bar"
+        })
+        assert.end()
+    })
+})
+
+test("[func] sends options.json as body when it's not a boolean", function(assert) {
+    xhr.post("/mock/echo", {
+        json: {
+            foo: "bar"
+        }
+    }, function(err, resp, body) {
+        assert.equal(resp.rawRequest.headers["Content-Type"], "application/json")
+        assert.deepEqual(body, {
+            foo: "bar"
+        })
         assert.end()
     })
 })

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -6,6 +6,15 @@ module.exports = function (req, res) {
     } else if (req.url === '/mock/no-content') {
         res.statusCode = 204
         res.end('')
+    } else if (req.url === '/mock/echo') {
+        var body = []
+        req.on('data', function(chunk) {
+            body.push(chunk)
+        })
+        req.on('end', function() {
+            res.statusCode = 200
+            res.end(Buffer.concat(body).toString())
+        })
     } else if (req.url === '/mock/timeout') {
         setTimeout(function() {
             res.statusCode = 200

--- a/test/mock-server.js
+++ b/test/mock-server.js
@@ -1,5 +1,5 @@
-module.exports = function (req, res) {
-    console.log('mock:',req.url)
+module.exports = function(req, res) {
+    console.log('mock:', req.url)
     if (req.url === '/mock/200ok') {
         res.statusCode = 200
         res.end('')
@@ -7,18 +7,12 @@ module.exports = function (req, res) {
         res.statusCode = 204
         res.end('')
     } else if (req.url === '/mock/echo') {
-        var body = []
-        req.on('data', function(chunk) {
-            body.push(chunk)
-        })
-        req.on('end', function() {
-            res.statusCode = 200
-            res.end(Buffer.concat(body).toString())
-        })
+        res.statusCode = 200
+        req.pipe(res)
     } else if (req.url === '/mock/timeout') {
         setTimeout(function() {
             res.statusCode = 200
             res.end()
         }, 100)
-    } 
+    }
 }


### PR DESCRIPTION
I took #135 and updated it to become a 99% backward compatible change.

The only change in behavior from previous version is not sending "true" as json body, which was incorrect anyway.

I believe we could even release this as a minor version update.
It depends if we consider it a breaking change or a bugfix that only affects a case of invalid JSON.

Thoughts?