### PR TITLE
Don't default request body to null

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,6 +216,9 @@ function _createXHR(options) {
         options.beforeSend(xhr)
     }
 
+    // Microsoft Edge browsers may throw errors when calling xhr.send() with an undefined body, so we set the body to null if body is undefined.
+    // See https://github.com/naugtur/xhr/issues/100.
+    body = body || null;
     xhr.send(body)
 
     return xhr

--- a/index.js
+++ b/index.js
@@ -143,7 +143,7 @@ function _createXHR(options) {
     var aborted
     var uri = xhr.url = options.uri || options.url
     var method = xhr.method = options.method || "GET"
-    var body = options.body || options.data || null
+    var body = options.body || options.data
     var headers = xhr.headers = options.headers || {}
     var sync = !!options.sync
     var isJson = false


### PR DESCRIPTION
When `opts.body` and `opts.data` are `undefined` and `opts.json === true`, requests are being sent with the string `"null"`. This is because, in line 146, `var body = options.body || options.data || null`, resulting in `JSON.stringify(null)` on line 165, which returns the string.

This PR would remove the default value of `null` for the request body.