### PR TITLE
Ensure callback not called when request aborted

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function _createXHR(options) {
 
     function readystatechange() {
         if (xhr.readyState === 4) {
-            loadFunc()
+            setTimeout(loadFunc, 0)
         }
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -321,7 +321,7 @@ test("aborting XHR immediately prevents callback from being called", { timeout: 
 })
 
 test("aborting XHR asynchronously still prevents callback from being called", { timeout: 500 }, function(assert) {
-    var req = xhr({ uri: "/mock/200ok" }, function(err, response) {
+    var req = xhr({ uri: "/mock/timeout" }, function(err, response) {
         assert.fail('this callback should not be called');
     });
     setTimeout(function() {

--- a/test/index.js
+++ b/test/index.js
@@ -312,12 +312,22 @@ test("url signature with object", { timeout: 500 }, function(assert) {
     })
 })
 
-test("aborting XHR prevents callback from being called", { timeout: 500 }, function(assert) {
+test("aborting XHR immediately prevents callback from being called", { timeout: 500 }, function(assert) {
     var req = xhr({ uri: "/mock/200ok" }, function(err, response) {
         assert.fail('this callback should not be called');
     });
     req.abort();
     assert.end()
+})
+
+test("aborting XHR asynchronously still prevents callback from being called", { timeout: 500 }, function(assert) {
+    var req = xhr({ uri: "/mock/200ok" }, function(err, response) {
+        assert.fail('this callback should not be called');
+    });
+    setTimeout(function() {
+        req.abort();
+        assert.end()
+    }, 0)
 })
 
 test("XHR can be overridden", { timeout: 500 }, function(assert) {

--- a/test/index.js
+++ b/test/index.js
@@ -312,6 +312,14 @@ test("url signature with object", { timeout: 500 }, function(assert) {
     })
 })
 
+test("aborting XHR prevents callback from being called", { timeout: 500 }, function(assert) {
+    var req = xhr({ uri: "/mock/200ok" }, function(err, response) {
+        assert.fail('this callback should not be called');
+    });
+    req.abort();
+    assert.end()
+})
+
 test("XHR can be overridden", { timeout: 500 }, function(assert) {
     var xhrs = 0
     var noop = function() {}


### PR DESCRIPTION
When the xhr is aborted programmatically, the callback should not be called, but it still is. This patch prevents that.

Related to https://github.com/naugtur/xhr/issues/93, https://github.com/naugtur/xhr/issues/104