### PR TITLE
Handle error events correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,9 +90,6 @@ function _createXHR(options) {
 
     function errorFunc(evt) {
         clearTimeout(timeoutTimer)
-        if(!(evt instanceof Error)){
-            evt = new Error("" + (evt || "Unknown XMLHttpRequest Error") )
-        }
         evt.statusCode = 0
         return callback(evt, failureResponse)
     }
@@ -168,7 +165,9 @@ function _createXHR(options) {
 
     xhr.onreadystatechange = readystatechange
     xhr.onload = loadFunc
-    xhr.onerror = errorFunc
+    xhr.onerror = function () {
+        errorFunc(new Error('Network failure'))
+    }
     // IE9 must have onprogress be set to a unique function.
     xhr.onprogress = function () {
         // IE must die
@@ -176,7 +175,9 @@ function _createXHR(options) {
     xhr.onabort = function(){
         aborted = true;
     }
-    xhr.ontimeout = errorFunc
+    xhr.ontimeout = function () {
+        errorFunc(new Error('Timeout'))
+    }
     xhr.open(method, uri, !sync, options.username, options.password)
     //has to be after open
     if(!sync) {

--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function _createXHR(options) {
     xhr.onreadystatechange = readystatechange
     xhr.onload = loadFunc
     xhr.onerror = function () {
-        errorFunc(new Error('Network failure'))
+        errorFunc(new Error('Unknown XMLHttpRequest Error'))
     }
     // IE9 must have onprogress be set to a unique function.
     xhr.onprogress = function () {
@@ -176,7 +176,7 @@ function _createXHR(options) {
         aborted = true;
     }
     xhr.ontimeout = function () {
-        errorFunc(new Error('Timeout'))
+        errorFunc(new Error('XMLHttpRequest Timeout'))
     }
     xhr.open(method, uri, !sync, options.username, options.password)
     //has to be after open


### PR DESCRIPTION
The `onerror` and `ontimeout` handler are not calling back with errors but with error events (without any messages). Therefore the `errorFunc` is wrapping them as `Error: [ProgressEvent object]`. 

Here's my quick proposal on how to fix this. Just pass generic error messages to the `errorFunc`, then there will be no case where the error needs to be constructed there.

The spec can be quite helpful here: https://xhr.spec.whatwg.org/