### PR TITLE
fix comma left out in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install xhr
 var xhr = require("xhr")
 
 xhr({
-    method: "post"
+    method: "post",
     body: someJSONString,
     uri: "/foo",
     headers: {


### PR DESCRIPTION
a comma was left out in the code of example.