### PR TITLE
Fix getXML() avoid throwing exception

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,16 +227,16 @@ function _createXHR(options) {
 }
 
 function getXml(xhr) {
-    if (xhr.responseType === "document") {
-        return xhr.responseXML
-    }
+    // xhr.responseXML will throw Exception "InvalidStateError" or "DOMException"
+    // See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML.
     try {
-      // xhr.responseXML will throw Exception "InvalidStateError".
-      // See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML.
-      var firefoxBugTakenEffect = xhr.responseXML && xhr.responseXML.documentElement.nodeName === "parsererror"
-      if (xhr.responseType === "" && !firefoxBugTakenEffect) {
-          return xhr.responseXML
-      }
+        if (xhr.responseType === "document") {
+            return xhr.responseXML
+        }
+        var firefoxBugTakenEffect = xhr.responseXML && xhr.responseXML.documentElement.nodeName === "parsererror"
+        if (xhr.responseType === "" && !firefoxBugTakenEffect) {
+            return xhr.responseXML
+        }
     } catch (e) {}
 
     return null

--- a/index.js
+++ b/index.js
@@ -230,10 +230,14 @@ function getXml(xhr) {
     if (xhr.responseType === "document") {
         return xhr.responseXML
     }
-    var firefoxBugTakenEffect = xhr.responseXML && xhr.responseXML.documentElement.nodeName === "parsererror"
-    if (xhr.responseType === "" && !firefoxBugTakenEffect) {
-        return xhr.responseXML
-    }
+    try {
+      // xhr.responseXML will throw Exception "InvalidStateError".
+      // See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML.
+      var firefoxBugTakenEffect = xhr.responseXML && xhr.responseXML.documentElement.nodeName === "parsererror"
+      if (xhr.responseType === "" && !firefoxBugTakenEffect) {
+          return xhr.responseXML
+      }
+    } catch (e) {}
 
     return null
 }


### PR DESCRIPTION
The XMLHttpRequest.responseXML property will return `document` or `null`, and throw an exception.

> **InvalidStateError**
> The responseType isn't either "document" or an empty string (either of which indicates that the  received data is XML or HTML). 

See: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML